### PR TITLE
refactor: Authentication(인증정보) 생성 시 principal 수정

### DIFF
--- a/src/main/java/com/project/matchimban/api/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/project/matchimban/api/auth/jwt/JwtProvider.java
@@ -106,6 +106,6 @@ public class JwtProvider {
 
     public Authentication getAuthenticationByToken(String token) {
         UserDetails userDetails = customUserDetailsService.loadUserByUsername(this.getEmailByToken(token));
-        return new UsernamePasswordAuthenticationToken(token, "", userDetails.getAuthorities());
+        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
     }
 }


### PR DESCRIPTION
기존에 token을 principal에 저장하고 있어서, 현재 인증된 사용자 정보를 가져오면 token값이 가져오는 상황 발생. 이를 해결하여 principal에 userDetails가 저장되도록 코드 수정